### PR TITLE
added more distink secondary highlight highlight

### DIFF
--- a/themes/stellaris-color-theme.json
+++ b/themes/stellaris-color-theme.json
@@ -5,7 +5,6 @@
 	"colors": {
 		"foreground": "#bbb",
 		"focusBorder": "#2C704D80",
-
 		"activityBar.background": "#1B2822",
 		"activityBar.foreground": "#6CFDDE",
 		"activityBarBadge.background": "#0b9248",
@@ -16,6 +15,7 @@
 		"editorLineNumber.foreground": "#3CbF90",
 		"editorLineNumber.activeForeground": "#D69123",
 		"editor.selectionBackground": "#463216",		
+		"editor.selectionHighlightBackground": "#2b6b6da1",
 		"editorGroupHeader.tabsBackground": "#1B2822",
 		"editorWidget.background": "#224433e0",
 		"editorWidget.resizeBorder": "#73D9B0",


### PR DESCRIPTION
I was finding, when I selected a word or text, the default secondary highlight of similar words was very hard to see compared to the background. I added a specific color item that I believe matching the existing theme while making it much easier to see for the user.